### PR TITLE
BUG: ResBlock with stride>2

### DIFF
--- a/fastai/vision/models/xresnet.py
+++ b/fastai/vision/models/xresnet.py
@@ -43,7 +43,7 @@ class ResBlock(Module):
         self.convs = nn.Sequential(*layers)
         # TODO: check whether act=True works better
         self.idconv = noop if ni==nf else conv_layer(ni, nf, 1, act=False)
-        self.pool = noop if stride==1 else nn.AvgPool2d(2, ceil_mode=True)
+        self.pool = noop if stride==1 else nn.AvgPool2d(stride, ceil_mode=True)
 
     def forward(self, x): return act_fn(self.convs(x) + self.idconv(self.pool(x)))
 


### PR DESCRIPTION
The pooling kernel on the identity block needs to match the stride on the conv block so the shapes match up. Previously it was hard-coded to be a pooling kernel of 2 if the conv stride was not 1.

This bug has probably not been seen in the wild because ResBlock is only ever called with stride of 1 or 2.

 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [x] Read the [contributing docs](https://github.com/fastai/fastai/blob/master/CONTRIBUTING.md)
 - [ ] Include a test in your PR that fails without your code, and passes with it, as well as a test of a case that already worked without your code (and still works with it). Currently fastai has poor test coverage, so don't take the current tests as a role model - we're all working to fix it together!
 - [x] Add details about your PR.
